### PR TITLE
feat: Add more context to error messages

### DIFF
--- a/create.go
+++ b/create.go
@@ -10,27 +10,27 @@ import (
 var createInputRegex = regexp.MustCompile(`^\S+$`)
 
 // ErrNameInvalid is returned if the appName contains any whitespace characters
-var ErrNameInvalid = errors.New("invalid appName format")
+var ErrNameInvalid = errors.New("invalid appName")
 
 // ErrVersionInvalid is returned if the version contains any whitespace characters
-var ErrVersionInvalid = errors.New("invalid version format")
+var ErrVersionInvalid = errors.New("invalid version")
 
 // ErrEnvironmentInvalid is returned if the environment contains any whitespace characters
-var ErrEnvironmentInvalid = errors.New("invalid environment format")
+var ErrEnvironmentInvalid = errors.New("invalid environment")
 
 // Format will generate a useragent string which is compliant with RFC 22.
 func (ua *UserAgent) Format() (string, error) {
 	appNameMatch := createInputRegex.MatchString(ua.Name)
 	if !appNameMatch {
-		return "", ErrNameInvalid
+		return "", fmt.Errorf("error validating %q: %w", ua.Name, ErrNameInvalid)
 	}
 	versionMatch := createInputRegex.MatchString(ua.Version)
 	if !versionMatch {
-		return "", ErrVersionInvalid
+		return "", fmt.Errorf("error validating %q: %w", ua.Version, ErrVersionInvalid)
 	}
 	environmentMatch := createInputRegex.MatchString(ua.Environment)
 	if !environmentMatch {
-		return "", ErrEnvironmentInvalid
+		return "", fmt.Errorf("error validating %q: %w", ua.Environment, ErrEnvironmentInvalid)
 	}
 
 	var useragent strings.Builder

--- a/parse.go
+++ b/parse.go
@@ -3,6 +3,7 @@ package useragent
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 )
 
@@ -15,7 +16,7 @@ var userAgentRegex = regexp.MustCompile(`^(?P<name>\S+?)\/(?P<version>\S+?) \(Ki
 func Parse(userAgent string) (UserAgent, error) {
 	match := userAgentRegex.FindStringSubmatch(userAgent)
 	if match == nil {
-		return UserAgent{}, ErrInvalidFormat
+		return UserAgent{}, fmt.Errorf("%w: %q", ErrInvalidFormat, userAgent)
 	}
 	ua := UserAgent{
 		Name:        match[1],


### PR DESCRIPTION
It's better to have the values in error messages when debugging why the
user agent can't be parsed or formatted.

BREAKING CHANGE: This can break some users if they compared the exported
error types with == instead of errors.Is (but I think the chance of this
happening is pretty small)