### PR TITLE
feat: Add methods for one-line errorless string generation and prepared constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Useragent
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/kiwicom/go-useragent.svg)](https://pkg.go.dev/github.com/kiwicom/go-useragent)
+
 Useragent formatter and parser based on User-Agent guidelines at Kiwi.com.
 
 ## About

--- a/create.go
+++ b/create.go
@@ -20,17 +20,9 @@ var ErrEnvironmentInvalid = errors.New("invalid environment")
 
 // Format will generate a useragent string which is compliant with RFC 22.
 func (ua *UserAgent) Format() (string, error) {
-	appNameMatch := createInputRegex.MatchString(ua.Name)
-	if !appNameMatch {
-		return "", fmt.Errorf("error validating %q: %w", ua.Name, ErrNameInvalid)
-	}
-	versionMatch := createInputRegex.MatchString(ua.Version)
-	if !versionMatch {
-		return "", fmt.Errorf("error validating %q: %w", ua.Version, ErrVersionInvalid)
-	}
-	environmentMatch := createInputRegex.MatchString(ua.Environment)
-	if !environmentMatch {
-		return "", fmt.Errorf("error validating %q: %w", ua.Environment, ErrEnvironmentInvalid)
+	err := ua.Validate()
+	if err != nil {
+		return "", err
 	}
 
 	var useragent strings.Builder
@@ -44,4 +36,27 @@ func (ua *UserAgent) Format() (string, error) {
 	}
 
 	return useragent.String(), nil
+}
+
+var _ fmt.Stringer = UserAgent{}
+
+// String implements fmt.Stringer interface. It's a wrapper around
+// UserAgent.Format method. The `<invalid>` string is returned if any error
+// occurs during generation.
+func (ua UserAgent) String() string {
+	s, err := ua.Format()
+	if err != nil {
+		return "<invalid>"
+	}
+	return s
+}
+
+// MustFormat is like UserAgent.Format but panics if any errors occurred during generation.
+// It simplifies safe initialization of global variables holding default or prepared values of UserAgent.
+func (ua UserAgent) MustFormat() string {
+	s, err := ua.Format()
+	if err != nil {
+		panic(err)
+	}
+	return s
 }

--- a/create.go
+++ b/create.go
@@ -9,14 +9,14 @@ import (
 
 var createInputRegex = regexp.MustCompile(`^\S+$`)
 
-// ErrNameInvalid is returned if the appName contains any whitespace characters
-var ErrNameInvalid = errors.New("invalid appName")
-
-// ErrVersionInvalid is returned if the version contains any whitespace characters
-var ErrVersionInvalid = errors.New("invalid version")
-
-// ErrEnvironmentInvalid is returned if the environment contains any whitespace characters
-var ErrEnvironmentInvalid = errors.New("invalid environment")
+var (
+	// ErrNameInvalid is returned if the appName contains any whitespace characters
+	ErrNameInvalid = errors.New("invalid appName")
+	// ErrVersionInvalid is returned if the version contains any whitespace characters
+	ErrVersionInvalid = errors.New("invalid version")
+	// ErrEnvironmentInvalid is returned if the environment contains any whitespace characters
+	ErrEnvironmentInvalid = errors.New("invalid environment")
+)
 
 // Format will generate a useragent string which is compliant with RFC 22.
 func (ua *UserAgent) Format() (string, error) {

--- a/prepared.go
+++ b/prepared.go
@@ -1,0 +1,45 @@
+package useragent
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"runtime"
+	"runtime/debug"
+	"testing"
+)
+
+// FromModule generated UserAgent based on debug.ReadBuildInfo.
+// If no build info available (e.g. in tests) the error will be returned.
+func FromModule() (UserAgent, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return UserAgent{}, errors.New("cannot retrieve build info")
+	}
+	return fromModule(info.Main), nil
+}
+
+func fromModule(mod debug.Module) UserAgent {
+	_, moduleBase := path.Split(mod.Path) // get the last element of the full module path
+	return UserAgent{
+		Name:        moduleBase,
+		Version:     mod.Version,
+		Environment: "dev",
+		SystemInfo:  goSystemInfo(),
+	}
+}
+
+// Testing is a helper constructor to help with building UserAgent for tests.
+func Testing(t testing.TB) UserAgent {
+	t.Helper()
+	return UserAgent{
+		Name:        t.Name(),
+		Version:     runtime.Version(),
+		Environment: "testing",
+		SystemInfo:  goSystemInfo(),
+	}
+}
+
+func goSystemInfo() string {
+	return fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+}

--- a/prepared_test.go
+++ b/prepared_test.go
@@ -1,0 +1,42 @@
+package useragent
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_fromModule(t *testing.T) {
+	mod := debug.Module{
+		Path:    "foo/bar/baz",
+		Version: "v1.2.3-test",
+		Sum:     "doesn't matter",
+		Replace: nil,
+	}
+
+	want := UserAgent{
+		Name:        "baz",
+		Version:     "v1.2.3-test",
+		Environment: "dev", // hardcoded
+		SystemInfo:  fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+	}
+	got := fromModule(mod)
+	assert.NoError(t, got.Validate(), "generated UserAgent should be valid")
+	assert.Equal(t, want, got, "should generate expected UserAgent")
+
+}
+
+func TestTesting(t *testing.T) {
+	want := UserAgent{
+		Name:        "TestTesting", // name of the current test
+		Version:     runtime.Version(),
+		Environment: "testing",
+		SystemInfo:  goSystemInfo(),
+	}
+	got := Testing(t)
+	assert.NoError(t, got.Validate(), "generated UserAgent should be valid")
+	assert.Equal(t, want, got, "should generate expected UserAgent")
+}

--- a/ua.go
+++ b/ua.go
@@ -1,5 +1,7 @@
 package useragent
 
+import "fmt"
+
 // UserAgent contains all available fields in UserAgent according to RFC-22 rules.
 type UserAgent struct {
 	// Name is the service name
@@ -10,4 +12,23 @@ type UserAgent struct {
 	Environment string
 	// SystemInfo describes extra metadata (e.g. node-fetch 1.2)
 	SystemInfo string
+}
+
+// Validate an ua struct values and ensure that Format call generate a valid
+// useragent. Descriptive non-nil error will be returned if any field of the ua
+// contains value that prevents generation of correct RFC 22 useragent.
+func (ua UserAgent) Validate() error {
+	appNameMatch := createInputRegex.MatchString(ua.Name)
+	if !appNameMatch {
+		return fmt.Errorf("error validating %q: %w", ua.Name, ErrNameInvalid)
+	}
+	versionMatch := createInputRegex.MatchString(ua.Version)
+	if !versionMatch {
+		return fmt.Errorf("error validating %q: %w", ua.Version, ErrVersionInvalid)
+	}
+	environmentMatch := createInputRegex.MatchString(ua.Environment)
+	if !environmentMatch {
+		return fmt.Errorf("error validating %q: %w", ua.Environment, ErrEnvironmentInvalid)
+	}
+	return nil
 }


### PR DESCRIPTION
### feat: Add methods for one-line errorless string generation 

This commits:
- adds implementation of the fmt.Stringer interface to simplify passing
to the functions from the fmt package.
- extracts and exports method for validation.
- adds MustFormat method as an alternative for the initialization of
global variables or using in tests.

---

### chore: Group errors for better rendering in documentation.

---

### feat: Add predefined constructors for tests and modules 

This commit adds couple of simple constructors to simplify
initialization. One of them for tests with injection of test name.
Another one for generating UserAgent from module information injected
into binary by Go toolchain itself during build process.

Closes #7 